### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## `bevy_descendant_collector` - [0.7.0](https://github.com/AlexAegis/bevy_descendant_collector/compare/v0.6.0...v0.7.0) - 2026-06-22
 
 ### Other
+- *(bevy_descendant_collector)* release v0.7.0
+- upgrade to bevy 0.19
+
+## `bevy_descendant_collector_derive` - [0.7.0](https://github.com/AlexAegis/bevy_descendant_collector/compare/bevy_descendant_collector_derive-v0.6.0...bevy_descendant_collector_derive-v0.7.0) - 2026-06-22
+
+### Other
+- *(bevy_descendant_collector)* release v0.7.0
+
+## `bevy_descendant_collector` - [0.7.0](https://github.com/AlexAegis/bevy_descendant_collector/compare/v0.6.0...v0.7.0) - 2026-06-22
+
+### Other
 - upgrade to bevy 0.19


### PR DESCRIPTION



## 🤖 New release

* `bevy_descendant_collector_derive`: 0.6.0 -> 0.7.0
* `bevy_descendant_collector`: 0.6.0 -> 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `bevy_descendant_collector_derive`

<blockquote>


## `bevy_descendant_collector_derive` - [0.7.0](https://github.com/AlexAegis/bevy_descendant_collector/compare/bevy_descendant_collector_derive-v0.6.0...bevy_descendant_collector_derive-v0.7.0) - 2026-06-22

### Other
- *(bevy_descendant_collector)* release v0.7.0
</blockquote>

## `bevy_descendant_collector`

<blockquote>


## `bevy_descendant_collector` - [0.7.0](https://github.com/AlexAegis/bevy_descendant_collector/compare/v0.6.0...v0.7.0) - 2026-06-22

### Other
- *(bevy_descendant_collector)* release v0.7.0
- upgrade to bevy 0.19
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).